### PR TITLE
Update README with minimum OS level.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ Create new timers with `CMD+N`
 <img src="/screenshots/timer.png?raw=tru" width="262">
 
 Inspired by the **great** [Minutes widget](http://minutes.en.softonic.com/mac) from Nitram-nunca I've been using for years. But it wasn't maintained anymore (non-retina) + it was the only widget in my dashboard :)
+
+Timer requires OS X 10.11 or later.


### PR DESCRIPTION
Timer won't run on OS X releases before 10.11.
