### PR TITLE
Save window position

### DIFF
--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -8,8 +8,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
   
   private var staysOnTop = false {
     didSet {
-      for controller in controllers {
-        controller.window?.level = self.windowLevel()
+      for window in NSApplication.shared.windows {
+        window.level = self.windowLevel()
       }
     }
   }
@@ -34,8 +34,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
   }
   
   func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-    for controller in controllers {
-      controller.window?.makeKeyAndOrderFront(self)
+    for window in NSApplication.shared.windows {
+      window.makeKeyAndOrderFront(self)
     }
     return true
   }
@@ -53,19 +53,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
   }
   
   @objc func newDocument(_ sender: AnyObject?) {
-    let lastController = self.controllers.last
-    let controller = MVTimerController(closeToWindow: lastController?.window)
+    let controller = MVTimerController(closeToWindow: NSApplication.shared.keyWindow)
     controller.window?.level = self.windowLevel()
     controllers.append(controller)
   }
   
   @objc func handleClose(_ notification: Notification) {
-    if let window = notification.object as? NSWindow {
-      if let controller = self.controllerForWindow(window) {
-        if let index = controllers.index(of: controller) {
+    if let window = notification.object as? NSWindow,
+      let controller = window.windowController as? MVTimerController,
+      let index = controllers.index(of: controller) {
           controllers.remove(at: index)
-        }
-      }
     }
   }
   
@@ -79,15 +76,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
   
   private func registerDefaults() {
     UserDefaults.standard.register(defaults: [MVUserDefaultsKeys.staysOnTop: false])
-  }
-  
-  private func controllerForWindow(_ window: NSWindow) -> MVTimerController? {
-    for controller in controllers {
-      if controller.window == window {
-        return controller
-      }
-    }
-    return nil
   }
 
 }

--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -60,9 +60,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
   }
   
   @objc func handleClose(_ notification: Notification) {
-    if controllers.count <= 1 {
-      return
-    }
     if let window = notification.object as? NSWindow {
       if let controller = self.controllerForWindow(window) {
         if let index = controllers.index(of: controller) {

--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -4,7 +4,7 @@ import Cocoa
 class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDelegate {
   
   private var controllers: [MVTimerController] = []
-  private var currentlyInDock : MVTimerController?;
+  private var currentlyInDock : MVTimerController?
   
   private var staysOnTop = false {
     didSet {
@@ -61,6 +61,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
   @objc func handleClose(_ notification: Notification) {
     if let window = notification.object as? NSWindow,
       let controller = window.windowController as? MVTimerController,
+      controller != currentlyInDock,
       let index = controllers.index(of: controller) {
           controllers.remove(at: index)
     }

--- a/Timer/MVMainView.swift
+++ b/Timer/MVMainView.swift
@@ -2,7 +2,7 @@ import Cocoa
 
 class MVMainView: NSView {
   
-  var controller : MVTimerController?
+  weak var controller : MVTimerController?
   private let appDelegate: AppDelegate  = NSApplication.shared.delegate as! AppDelegate
   private var contextMenu: NSMenu?
   public  var menuItem : NSMenuItem?

--- a/Timer/MVTimerController.swift
+++ b/Timer/MVTimerController.swift
@@ -10,7 +10,6 @@ class MVTimerController: NSWindowController {
     let mainView = MVMainView(frame: NSZeroRect)
 
     let window = MVWindow(mainView: mainView)
-    //window.isReleasedWhenClosed = false
 
     self.init(window: window)
     

--- a/Timer/MVTimerController.swift
+++ b/Timer/MVTimerController.swift
@@ -10,7 +10,7 @@ class MVTimerController: NSWindowController {
     let mainView = MVMainView(frame: NSZeroRect)
 
     let window = MVWindow(mainView: mainView)
-    window.isReleasedWhenClosed = false
+    //window.isReleasedWhenClosed = false
 
     self.init(window: window)
     

--- a/Timer/MVTimerController.swift
+++ b/Timer/MVTimerController.swift
@@ -21,6 +21,8 @@ class MVTimerController: NSWindowController {
     self.clockView.action = #selector(handleClockTimer)
     self.mainView.addSubview(clockView)
     
+    self.windowFrameAutosaveName = NSWindow.FrameAutosaveName("TimerWindowAutosaveFrame")
+    
     window.makeKeyAndOrderFront(self)    
   }
   


### PR DESCRIPTION
To make this work, I also changed how windows are memory managed. I removed a strong reference cycle between the window and window controller so that windows will be released from memory when closed. The exception is the one window whose timer is being shown in the dock — we keep a strong reference to that window controller (and thus window), and it will come back onscreen if the dock icon is clicked.