### PR TITLE
Ability to remove the dock icon badge

### DIFF
--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -45,11 +45,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
   }
   
   func addBadgeToDock(controller: MVTimerController){
-    if currentlyInDock != nil {
-      currentlyInDock!.showInDock(false)
+    if currentlyInDock != controller {
+      self.removeBadgeFromDock()
     }
     currentlyInDock = controller
     controller.showInDock(true)
+  }
+  
+  func removeBadgeFromDock() {
+    if currentlyInDock != nil {
+      currentlyInDock!.showInDock(false)
+    }
   }
   
   @objc func newDocument(_ sender: AnyObject?) {

--- a/Timer/MVClockView.swift
+++ b/Timer/MVClockView.swift
@@ -17,6 +17,9 @@ class MVClockView: NSControl {
   private let docktile: NSDockTile = NSApplication.shared.dockTile
   public  var inDock : Bool = false{
     didSet{
+      if !inDock {
+        self.removeBadge()
+      }
       self.updateLabels()
     }
   }
@@ -316,10 +319,13 @@ class MVClockView: NSControl {
         let badgeMinutes = Int(self.minutes)
         self.docktile.badgeLabel = NSString(format:"%02d:%02d", badgeMinutes, badgeSeconds) as String
       } else {
-        self.docktile.badgeLabel = ""
+        self.removeBadge()
       }
     }
+  }
   
+  private func removeBadge() {
+    self.docktile.badgeLabel = ""
   }
   
   private func updateTimeLabel() {
@@ -342,7 +348,7 @@ class MVClockView: NSControl {
     self.timer = nil
 
     if (self.inDock && !self.paused){
-      self.docktile.badgeLabel = ""
+      self.removeBadge()
     }
   }
   

--- a/Timer/MVMainView.swift
+++ b/Timer/MVMainView.swift
@@ -15,7 +15,7 @@ class MVMainView: NSView {
     super.init(frame: frameRect)
     
     self.contextMenu = NSMenu(title: "Menu")
-    menuItem = NSMenuItem(title:"Show in Dock", action:#selector(self.addBadgeToDock), keyEquivalent:"")
+    menuItem = NSMenuItem(title:"Show in Dock", action:#selector(self.toggleShowInDock), keyEquivalent:"")
     self.contextMenu?.addItem(menuItem!)
     
     let nc = NotificationCenter.default
@@ -27,8 +27,12 @@ class MVMainView: NSView {
     fatalError("init(coder:) has not been implemented")
   }
   
-  @objc func addBadgeToDock(){
-    appDelegate.addBadgeToDock(controller: self.controller!)
+  @objc func toggleShowInDock() {
+    if menuItem?.state == .on {
+      appDelegate.removeBadgeFromDock()
+    } else {
+      appDelegate.addBadgeToDock(controller: self.controller!)
+    }
   }
   
   deinit {

--- a/Timer/MVTimerController.swift
+++ b/Timer/MVTimerController.swift
@@ -42,13 +42,9 @@ class MVTimerController: NSWindowController {
     self.clockView.stop()
   }
   
-  func showInDock(_ state: Bool){
+  func showInDock(_ state: Bool) {
     self.clockView.inDock = state
-    if state{
-      self.mainView.menuItem?.state = .on
-    } else {
-      self.mainView.menuItem?.state = .off
-    }
+    self.mainView.menuItem?.state = state ? .on : .off
   }
   
   @objc func handleClockTimer(_ clockView: MVClockView) {


### PR DESCRIPTION
If you right-click on a timer whose countdown is shown in the dock, you get a "Show in Dock" menu item with a check mark next to it.

This pull request lets you click that menu item again to uncheck it and remove the badge from the dock. (You can of course put it back anytime with the same menu item.)