### PR TITLE
Reduce energy consumption

### DIFF
--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -29,6 +29,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
     let nc = NotificationCenter.default
     nc.addObserver(self, selector: #selector(handleClose), name: NSWindow.willCloseNotification, object: nil)
     nc.addObserver(self, selector: #selector(handleUserDefaultsChange), name: UserDefaults.didChangeNotification, object: nil)
+    nc.addObserver(self, selector: #selector(handleOcclusionChange), name: NSWindow.didChangeOcclusionStateNotification, object: nil)
     
     staysOnTop = UserDefaults.standard.bool(forKey: MVUserDefaultsKeys.staysOnTop)
   }
@@ -70,6 +71,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
       controller != currentlyInDock,
       let index = controllers.index(of: controller) {
           controllers.remove(at: index)
+    }
+  }
+  
+  @objc func handleOcclusionChange(_ notification: Notification) {
+    if let window = notification.object as? NSWindow,
+      let controller = window.windowController as? MVTimerController
+    {
+      controller.windowVisibilityChanged(window.isVisible)
     }
   }
   

--- a/Timer/MVClockView.swift
+++ b/Timer/MVClockView.swift
@@ -375,7 +375,7 @@ class MVClockView: NSControl {
     self.paused = false
     self.stop()
     self.timer = Foundation.Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(tick), userInfo: nil, repeats: true)
-    self.timer?.tolerance = 0.1 // improve battery life
+    self.timer?.tolerance = 0.03 // improve battery life
   }
   
   func stop() {

--- a/Timer/MVTimerController.swift
+++ b/Timer/MVTimerController.swift
@@ -46,6 +46,10 @@ class MVTimerController: NSWindowController {
     self.mainView.menuItem?.state = state ? .on : .off
   }
   
+  func windowVisibilityChanged(_ visible:Bool) {
+    clockView.windowIsVisible = visible
+  }
+  
   @objc func handleClockTimer(_ clockView: MVClockView) {
     let notification = NSUserNotification()
     notification.title = "It's time! 🕘"


### PR DESCRIPTION
I noticed that the app was consistently using 2-3% CPU, even when running in the background on my relatively fast iMac. Part of the reason was that the timer UI was being redrawn 10 times per second even when the window was hidden.

With these revisions, energy consumption is now near zero in all situations when the user is not directly interacting with the app. The UI is only redrawn once per second when a timer is counting down, and never when the window is hidden (and the dock badge countdown still works). This gives me peace of mind knowing that I can have a timer running in the background without draining my battery.