### PR TITLE
Update window layout to work on macOS 10.14 (Mojave)

### DIFF
--- a/Timer/MVWindow.swift
+++ b/Timer/MVWindow.swift
@@ -26,34 +26,23 @@ class MVWindow: NSWindow {
     self.titleVisibility = .hidden
     self.titlebarAppearsTransparent = true
     
+    // Create a transparent titlebar accessory to overlay the window (to capture drag events)
     let titleBarController = MVTitlebarAccessoryViewController()
     titleBarController.view.frame = NSMakeRect(0, 0, size, windowFrame.size.height)
     self.addTitlebarAccessoryViewController(titleBarController)
     
-    self.layoutSubviews()
-  }
-  
-  func layoutSubviews() {
-    // Display main view
-    if let themeFrame = self.contentView?.superview as NSView?,
-        let firstSubview = themeFrame.subviews[1] as NSView?,
-        let subSubView = firstSubview.subviews[0] as NSView? {
-          firstSubview.addSubview(self.mainView,
-                                  positioned: .below,
-                                  relativeTo: subSubView)
-    }
+    // Hide some of the default window buttons
+    self.standardWindowButton(.miniaturizeButton)?.isHidden = true
+    self.standardWindowButton(.zoomButton)?.isHidden = true
     
-    // Hide controls
-    let close = self.standardWindowButton(.closeButton)!
-    var closeFrame = close.frame
+    // Adjust the close button
+    let closeButton = self.standardWindowButton(.closeButton)!
+    var closeFrame = closeButton.frame
     closeFrame.origin.y -= 2
-    close.frame = closeFrame
+    closeButton.frame = closeFrame
     
-    let minimize = self.standardWindowButton(.miniaturizeButton)
-    minimize?.isHidden = true
-    
-    let zoom = self.standardWindowButton(.zoomButton)
-    zoom?.isHidden = true
+    // Add the main clock view as a sibling underneath the close button
+    closeButton.superview?.addSubview(self.mainView, positioned: .below, relativeTo: closeButton)
   }
   
 }


### PR DESCRIPTION
It took me a while to figure out what was going on in the view hierarchy, causing the clock to not get displayed on Mojave. Ideally I'd like to move to an approach that puts the clock in a more standard location in the view hierarchy that would be more robust to OS updates (such as `contentView`). But after experimenting for a while, I don't have any clear idea of how to do that while maintaining the visual design and behavior.

So instead I was able to adapt the approach for Mojave by simply making the clock view a sibling of the close button.

I also simplified a few lines of code and added comments.