### PR TITLE
add feature - press `r` to restart with the last timer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ Enter digits to set minutes. A decimal point specifies seconds so `2.34` is 2 mi
 <kbd>backspace</kbd> or <kbd>escape</kbd> to edit.
 <kbd>enter</kbd> to start or pause the timer.
 <kbd>cmd</kbd>+<kbd>n</kbd> to create a new timer.
+<kbd>r</kbd> to restart with the last timer.

--- a/Timer/MVClockView.swift
+++ b/Timer/MVClockView.swift
@@ -14,6 +14,7 @@ class MVClockView: NSControl {
   private var secondsLabel: NSTextView!
   private var secondsSuffixWidth: CGFloat = 0.0
   private var inputSeconds: Bool = false
+  private var lastTimerSeconds: CGFloat?
   private let docktile: NSDockTile = NSApplication.shared.dockTile
   public  var inDock : Bool = false{
     didSet{
@@ -294,6 +295,13 @@ class MVClockView: NSControl {
     } else if (key == Keycode.returnKey || key == Keycode.space || key == Keycode.keypadEnter) {
       // "Enter" or "Space" or "Keypad Enter"
       self.handleClick();
+    } else if (key == Keycode.r && self.timer == nil && self.paused != true) {
+      // "r" for restarting with the last timer
+      if let seconds = self.lastTimerSeconds {
+        self.seconds = seconds
+        self.handleClick()
+      }
+        
     }
   }
 
@@ -375,6 +383,7 @@ class MVClockView: NSControl {
 
   private func start() {
     guard self.seconds > 0  else { return }
+    self.lastTimerSeconds = self.seconds
 
     self.paused = false
     self.stop()


### PR DESCRIPTION
This pull request adds a feature to restart with the last timer when the `r` key is pressed when the last timer runs out or after `esc` is pressed. 

Saving a few keystrokes several times a day can really add up ! 