### PR TITLE
Fix countdown display skipping seconds

### DIFF
--- a/Timer/MVClockView.swift
+++ b/Timer/MVClockView.swift
@@ -14,6 +14,7 @@ class MVClockView: NSControl {
   private var secondsSuffixWidth: CGFloat = 0.0
   private var inputSeconds: Bool = false
   private var lastTimerSeconds: CGFloat?
+  private var firstTick: Bool = false
   private let docktile: NSDockTile = NSApplication.shared.dockTile
   public  var inDock: Bool = false {
     didSet {
@@ -406,17 +407,17 @@ class MVClockView: NSControl {
     self.lastTimerSeconds = self.seconds
 
     self.paused = false
+    self.firstTick = true
     self.stop()
 
-    // Ensure that each countdown tick occurs just past the exact seconds boundary
-    // (so system delays won't affect the value displayed)
     self.timer = Timer.scheduledTimer(
-      timeInterval: 0.97,
+      timeInterval: 1,
       target: self,
-      selector: #selector(firstTick),
+      selector: #selector(tick),
       userInfo: nil,
-      repeats: false
+      repeats: true
     )
+    self.timer?.tolerance = 0.03
   }
 
   func stop() {
@@ -428,25 +429,18 @@ class MVClockView: NSControl {
     }
   }
 
-  @objc func firstTick() {
-    self.tick()
-    self.timer = Foundation.Timer.scheduledTimer(
-      timeInterval: 1,
-      target: self,
-      selector: #selector(tick),
-      userInfo: nil,
-      repeats: true
-    )
-
-    // Improves the system's ability to optimize for increased power savings and responsiveness
-    // A general rule, set the tolerance to at least 10% of the interval, for a repeating timer.
-    currentTimeTimer?.tolerance = 0.03
-  }
-
   @objc func tick() {
     guard let timerTime = self.timerTime  else { return }
-
-    self.seconds = fmax(0, floor(CGFloat(timerTime.timeIntervalSinceNow)))
+    self.seconds -= 1
+    if self.firstTick == true {
+      self.updateTimerTime()
+      self.firstTick = false
+      return
+    }
+    let wallTime = fmax(0, floor(CGFloat(timerTime.timeIntervalSinceNow)))
+    if (self.seconds - wallTime) > 1 { // maintain correct countdown even if thread was sleeping or falls behind
+      self.seconds = wallTime
+    }
     if self.seconds <= 0 {
       self.stop()
       _ = self.target?.perform(self.action, with: self)


### PR DESCRIPTION
This is my attempt to fix the second-skipping display bug (see pull #91 and issue #90)

Instead of changing the tick display based on the "wall time", this decrements the seconds counter based on the timer interval itself, which should be the correct behavior since it won't be affected by alignment with the system clock.

An additional check was added to deal with cases when the thread is paused e.g. when the lid is closed on a laptop or the user is interacting with the menu bar.

Fix countdown display skipping seconds

Fixes #90 
Closes #91 