### PR TITLE
update cask install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Create new timers with `CMD+N`.
 Install as a [brew cask](https://caskroom.github.io) via 
 
 ```shell
-brew cask install michaelvillar-timer
+brew install --cask michaelvillar-timer
 ```
 
 Inspired by the **great** [Minutes widget](http://minutes.en.softonic.com/mac) from Nitram-nunca I've been using for years. But it wasn't maintained anymore (non-retina) + it was the only widget in my dashboard :)


### PR DESCRIPTION
Installing following the description it result in an error (Error: Calling brew cask install is disabled! Use brew install [--cask] instead.) since the command for installing casks has been updated

![image](https://user-images.githubusercontent.com/7412876/103637333-a1c33b00-4f4b-11eb-9b68-a01db20e7d87.png)
