### PR TITLE
View preferences

### DIFF
--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -20,6 +20,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
 
   func applicationDidFinishLaunching(_ aNotification: Notification) {
     let controller = MVTimerController()
+    controller.isMainController = true
     controllers.append(controller)
     self.addBadgeToDock(controller: controller)
 
@@ -81,6 +82,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
   @objc func newDocument(_ sender: AnyObject?) {
     let controller = MVTimerController(closeToWindow: NSApplication.shared.keyWindow)
     controller.window?.level = self.windowLevel()
+    controller.isMainController = controllers.isEmpty
     controllers.append(controller)
   }
 
@@ -109,6 +111,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
   }
 
   private func registerDefaults() {
-    UserDefaults.standard.register(defaults: [MVUserDefaultsKeys.staysOnTop: false])
+    UserDefaults.standard.register(defaults: [
+      MVUserDefaultsKeys.staysOnTop: false,
+    ])
   }
 }

--- a/Timer/MVMainView.swift
+++ b/Timer/MVMainView.swift
@@ -52,9 +52,20 @@ class MVMainView: NSView {
         submenu.addItem(soundItem)
     }
     self.soundMenuItems.first?.state = .on
+
+    let menuItemViewConfig = NSMenuItem(
+      title: "View",
+      action: nil,
+      keyEquivalent: ""
+    )
+    let submenuViewConfig = NSMenu()
+    submenuViewConfig.autoenablesItems = false
+
     self.contextMenu?.addItem(menuItem!)
     self.contextMenu?.addItem(menuItemSoundChoice)
     self.contextMenu?.setSubmenu(submenu, for: menuItemSoundChoice)
+    self.contextMenu?.addItem(menuItemViewConfig)
+    self.contextMenu?.setSubmenu(submenuViewConfig, for: menuItemViewConfig)
 
     let notificationCenter = NotificationCenter.default
 
@@ -99,6 +110,15 @@ class MVMainView: NSView {
     }
     if let soundIdx = sender.representedObject as? Int {
         self.controller!.pickSound(soundIdx)
+    }
+  }
+
+  @objc func toggleViewItemState(_ sender: NSMenuItem) {
+    var value = sender.state == .on ? true : false
+    value.toggle()
+    switch sender {
+    default:
+      break
     }
   }
 

--- a/Timer/MVTimerController.swift
+++ b/Timer/MVTimerController.swift
@@ -8,6 +8,8 @@ class MVTimerController: NSWindowController {
   private var audioPlayer: AVAudioPlayer? // player must be kept in memory
   private var soundURL = Bundle.main.url(forResource: "alert-sound", withExtension: "caf")
 
+  var isMainController: Bool = false
+
   convenience init() {
     let mainView = MVMainView(frame: NSRect.zero)
 
@@ -25,6 +27,8 @@ class MVTimerController: NSWindowController {
     self.windowFrameAutosaveName = "TimerWindowAutosaveFrame"
 
     window.makeKeyAndOrderFront(self)
+
+    loadViewStateFromUserDefaults()
   }
 
   convenience init(closeToWindow: NSWindow?) {
@@ -107,10 +111,26 @@ class MVTimerController: NSWindowController {
   }
 
   func setViewState(_ value: Bool, forKey viewConfigKey: String) {
+    setViewState(value, forKey: viewConfigKey, save: isMainController)
+  }
+
+  private func setViewState(_ value: Bool, forKey viewConfigKey: String, save: Bool) {
     let state: NSControl.StateValue = value ? .on : .off
     switch viewConfigKey {
     default:
       break
+    }
+    if save {
+      UserDefaults.standard.set(value, forKey: viewConfigKey)
+    }
+  }
+
+  private func loadViewStateFromUserDefaults() {
+    let keys: [String] = [
+    ]
+    for key in keys {
+      let value = UserDefaults.standard.bool(forKey: key)
+      setViewState(value, forKey: key, save: false)
     }
   }
 }

--- a/Timer/MVTimerController.swift
+++ b/Timer/MVTimerController.swift
@@ -105,4 +105,12 @@ class MVTimerController: NSWindowController {
         self.soundURL = nil
     }
   }
+
+  func setViewState(_ value: Bool, forKey viewConfigKey: String) {
+    let state: NSControl.StateValue = value ? .on : .off
+    switch viewConfigKey {
+    default:
+      break
+    }
+  }
 }


### PR DESCRIPTION
Prepares the app for visual customisations by adding a 'View' menu item as well as some placeholder code to save and load preferences from UserDefaults. Added an `isMainController` field so that only changes made in the first window are saved.

This PR serves as a base for some other PRs I'm about to open.