### PR TITLE
Option to show a full disk timer

### DIFF
--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -20,6 +20,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
 
   func applicationDidFinishLaunching(_ aNotification: Notification) {
     let controller = MVTimerController()
+    controller.isMainController = true
     controllers.append(controller)
     self.addBadgeToDock(controller: controller)
 
@@ -81,6 +82,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
   @objc func newDocument(_ sender: AnyObject?) {
     let controller = MVTimerController(closeToWindow: NSApplication.shared.keyWindow)
     controller.window?.level = self.windowLevel()
+    controller.isMainController = controllers.isEmpty
     controllers.append(controller)
   }
 
@@ -109,6 +111,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
   }
 
   private func registerDefaults() {
-    UserDefaults.standard.register(defaults: [MVUserDefaultsKeys.staysOnTop: false])
+    UserDefaults.standard.register(defaults: [
+      MVUserDefaultsKeys.staysOnTop: false,
+    ])
   }
 }

--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -113,6 +113,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
   private func registerDefaults() {
     UserDefaults.standard.register(defaults: [
       MVUserDefaultsKeys.staysOnTop: false,
+      MVUserDefaultsKeys.fullDiskTimer: false
     ])
   }
 }

--- a/Timer/MVClockView.swift
+++ b/Timer/MVClockView.swift
@@ -188,6 +188,15 @@ class MVClockView: NSControl {
     self.arrowView.progress = progress
   }
 
+  func showFullDiskTimer(_ progressViewAboveClock: Bool) {
+    progressView.removeFromSuperview()
+    if progressViewAboveClock {
+      self.addSubview(progressView, positioned: .above, relativeTo:clockFaceView)
+    } else {
+      self.addSubview(progressView, positioned: .below, relativeTo:arrowView)
+    }
+  }
+
   @objc func handleArrowControl(_ object: NSNumber) {
     var progressValue = CGFloat(object.floatValue)
     progressValue = convertProgressToScale(progressValue)

--- a/Timer/MVClockView.swift
+++ b/Timer/MVClockView.swift
@@ -5,7 +5,6 @@ class MVClockView: NSControl {
   private var pauseIconImageView: NSImageView!
   private var progressView: MVClockProgressView!
   private var arrowView: MVClockArrowView!
-  private var timerTimeLabel: NSTextView!
   private var timerTimeLabelFontSize: CGFloat = 15
   private var minutesLabel: NSTextView!
   private var minutesLabelSuffixWidth: CGFloat = 0.0
@@ -47,6 +46,7 @@ class MVClockView: NSControl {
       self.layoutPauseViews()
     }
   }
+  var timerTimeLabel: NSTextView!
 
   var seconds: CGFloat = 0.0 {
     didSet {

--- a/Timer/MVMainView.swift
+++ b/Timer/MVMainView.swift
@@ -52,9 +52,20 @@ class MVMainView: NSView {
         submenu.addItem(soundItem)
     }
     self.soundMenuItems.first?.state = .on
+
+    let menuItemViewConfig = NSMenuItem(
+      title: "View",
+      action: nil,
+      keyEquivalent: ""
+    )
+    let submenuViewConfig = NSMenu()
+    submenuViewConfig.autoenablesItems = false
+
     self.contextMenu?.addItem(menuItem!)
     self.contextMenu?.addItem(menuItemSoundChoice)
     self.contextMenu?.setSubmenu(submenu, for: menuItemSoundChoice)
+    self.contextMenu?.addItem(menuItemViewConfig)
+    self.contextMenu?.setSubmenu(submenuViewConfig, for: menuItemViewConfig)
 
     let notificationCenter = NotificationCenter.default
 
@@ -99,6 +110,15 @@ class MVMainView: NSView {
     }
     if let soundIdx = sender.representedObject as? Int {
         self.controller!.pickSound(soundIdx)
+    }
+  }
+
+  @objc func toggleViewItemState(_ sender: NSMenuItem) {
+    var value = sender.state == .on ? true : false
+    value.toggle()
+    switch sender {
+    default:
+      break
     }
   }
 

--- a/Timer/MVMainView.swift
+++ b/Timer/MVMainView.swift
@@ -16,6 +16,7 @@ class MVMainView: NSView {
   private var contextMenu: NSMenu?
   public  var menuItem: NSMenuItem?
   private var soundMenuItems: [NSMenuItem] = []
+  var fullDiskTimerMenuItem: NSMenuItem?
 
   // swiftlint:disable unused_setter_value
   override var menu: NSMenu? {
@@ -60,6 +61,13 @@ class MVMainView: NSView {
     )
     let submenuViewConfig = NSMenu()
     submenuViewConfig.autoenablesItems = false
+
+    fullDiskTimerMenuItem = NSMenuItem(
+      title: "Show full disk timer",
+      action: #selector(self.toggleViewItemState),
+      keyEquivalent: ""
+    )
+    submenuViewConfig.addItem(fullDiskTimerMenuItem!)
 
     self.contextMenu?.addItem(menuItem!)
     self.contextMenu?.addItem(menuItemSoundChoice)
@@ -117,6 +125,8 @@ class MVMainView: NSView {
     var value = sender.state == .on ? true : false
     value.toggle()
     switch sender {
+    case fullDiskTimerMenuItem:
+      self.controller?.setViewState(value, forKey: MVUserDefaultsKeys.fullDiskTimer)
     default:
       break
     }

--- a/Timer/MVTimerController.swift
+++ b/Timer/MVTimerController.swift
@@ -120,6 +120,7 @@ class MVTimerController: NSWindowController {
     case MVUserDefaultsKeys.fullDiskTimer:
       mainView.fullDiskTimerMenuItem?.state = state
       clockView.showFullDiskTimer(value)
+      clockView.timerTimeLabel.isHidden = value
     default:
       break
     }

--- a/Timer/MVTimerController.swift
+++ b/Timer/MVTimerController.swift
@@ -8,6 +8,8 @@ class MVTimerController: NSWindowController {
   private var audioPlayer: AVAudioPlayer? // player must be kept in memory
   private var soundURL = Bundle.main.url(forResource: "alert-sound", withExtension: "caf")
 
+  var isMainController: Bool = false
+
   convenience init() {
     let mainView = MVMainView(frame: NSRect.zero)
 
@@ -25,6 +27,8 @@ class MVTimerController: NSWindowController {
     self.windowFrameAutosaveName = "TimerWindowAutosaveFrame"
 
     window.makeKeyAndOrderFront(self)
+
+    loadViewStateFromUserDefaults()
   }
 
   convenience init(closeToWindow: NSWindow?) {
@@ -107,10 +111,26 @@ class MVTimerController: NSWindowController {
   }
 
   func setViewState(_ value: Bool, forKey viewConfigKey: String) {
+    setViewState(value, forKey: viewConfigKey, save: isMainController)
+  }
+
+  private func setViewState(_ value: Bool, forKey viewConfigKey: String, save: Bool) {
     let state: NSControl.StateValue = value ? .on : .off
     switch viewConfigKey {
     default:
       break
+    }
+    if save {
+      UserDefaults.standard.set(value, forKey: viewConfigKey)
+    }
+  }
+
+  private func loadViewStateFromUserDefaults() {
+    let keys: [String] = [
+    ]
+    for key in keys {
+      let value = UserDefaults.standard.bool(forKey: key)
+      setViewState(value, forKey: key, save: false)
     }
   }
 }

--- a/Timer/MVTimerController.swift
+++ b/Timer/MVTimerController.swift
@@ -105,4 +105,12 @@ class MVTimerController: NSWindowController {
         self.soundURL = nil
     }
   }
+
+  func setViewState(_ value: Bool, forKey viewConfigKey: String) {
+    let state: NSControl.StateValue = value ? .on : .off
+    switch viewConfigKey {
+    default:
+      break
+    }
+  }
 }

--- a/Timer/MVTimerController.swift
+++ b/Timer/MVTimerController.swift
@@ -117,6 +117,9 @@ class MVTimerController: NSWindowController {
   private func setViewState(_ value: Bool, forKey viewConfigKey: String, save: Bool) {
     let state: NSControl.StateValue = value ? .on : .off
     switch viewConfigKey {
+    case MVUserDefaultsKeys.fullDiskTimer:
+      mainView.fullDiskTimerMenuItem?.state = state
+      clockView.showFullDiskTimer(value)
     default:
       break
     }
@@ -127,6 +130,7 @@ class MVTimerController: NSWindowController {
 
   private func loadViewStateFromUserDefaults() {
     let keys: [String] = [
+      MVUserDefaultsKeys.fullDiskTimer
     ]
     for key in keys {
       let value = UserDefaults.standard.bool(forKey: key)

--- a/Timer/MVUserDefaultsKeys.swift
+++ b/Timer/MVUserDefaultsKeys.swift
@@ -1,3 +1,4 @@
 struct MVUserDefaultsKeys {
   static let staysOnTop = "staysOnTop"
+  static let fullDiskTimer = "fullDiskTimer"
 }


### PR DESCRIPTION
Instead of just a blue arrow and line around the clock, this provides the option to fill the entire clock face. It makes the visual countdown more prominent which is useful for people who have ADHD and other such attention issues – visual countdowns help externalise the passage of time which helps us pay more attention to it.

Enabling this option also hides the digital timer since it didn't look aesthetically pleasing IMO.

Depends on #125.