### PR TITLE
Add cursor feedback to arrow drag control

### DIFF
--- a/Timer/MVClockArrowView.swift
+++ b/Timer/MVClockArrowView.swift
@@ -43,7 +43,12 @@ final class MVClockArrowView: NSView {
     path.fill()
   }
 
+  override func resetCursorRects() {
+    self.addCursorRect(self.bounds, cursor: .openHand)
+  }
+
   override func mouseDown(with event: NSEvent) {
+    NSCursor.closedHand.push()
     var isDragging = false
     var isTracking = true
     var trackingEvent: NSEvent = event
@@ -52,6 +57,7 @@ final class MVClockArrowView: NSView {
       switch trackingEvent.type {
       case .leftMouseUp:
         isTracking = false
+        NSCursor.pop()
         self.handleUp()
 
       case .leftMouseDragged:


### PR DESCRIPTION
## Summary

- Show open hand cursor when hovering over the arrow control (indicates draggable)
- Switch to closed hand cursor while actively dragging
- Follows [Apple HIG guidelines](https://developer.apple.com/design/human-interface-guidelines/pointing-devices) for draggable controls

Closes #23