### PR TITLE
Add scroll wheel input and improve label contrast

### DIFF
--- a/Timer/Assets.xcassets/minutes-color.colorset/Contents.json
+++ b/Timer/Assets.xcassets/minutes-color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.271",
-          "green" : "0.255",
-          "red" : "0.235"
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.882",
-          "green" : "0.871",
-          "red" : "0.851"
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
         }
       },
       "idiom" : "universal"

--- a/Timer/Assets.xcassets/minutes-color.colorset/Contents.json
+++ b/Timer/Assets.xcassets/minutes-color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.000",
-          "green" : "0.000",
-          "red" : "0.000"
+          "blue" : "0.098",
+          "green" : "0.098",
+          "red" : "0.098"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.000",
-          "green" : "0.000",
-          "red" : "0.000"
+          "blue" : "0.098",
+          "green" : "0.098",
+          "red" : "0.098"
         }
       },
       "idiom" : "universal"

--- a/Timer/Assets.xcassets/seconds-color.colorset/Contents.json
+++ b/Timer/Assets.xcassets/seconds-color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.686",
-          "green" : "0.667",
-          "red" : "0.635"
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.584",
-          "green" : "0.569",
-          "red" : "0.549"
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
         }
       },
       "idiom" : "universal"

--- a/Timer/Assets.xcassets/seconds-color.colorset/Contents.json
+++ b/Timer/Assets.xcassets/seconds-color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.000",
-          "green" : "0.000",
-          "red" : "0.000"
+          "blue" : "0.098",
+          "green" : "0.098",
+          "red" : "0.098"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.000",
-          "green" : "0.000",
-          "red" : "0.000"
+          "blue" : "0.098",
+          "green" : "0.098",
+          "red" : "0.098"
         }
       },
       "idiom" : "universal"

--- a/Timer/MVClockView+Behavior.swift
+++ b/Timer/MVClockView+Behavior.swift
@@ -16,6 +16,31 @@ extension MVClockView {
     }
   }
 
+  override func scrollWheel(with event: NSEvent) {
+    guard self.timerTask == nil, !self.paused else { return }
+
+    let delta: CGFloat
+    if event.hasPreciseScrollingDeltas {
+      delta = event.scrollingDeltaY * 3
+    } else {
+      delta = event.scrollingDeltaY * 30
+    }
+
+    guard delta != 0 else { return }
+
+    var newSeconds = self.seconds + delta
+    newSeconds = max(0, newSeconds)
+
+    if newSeconds <= 300 {
+      newSeconds -= newSeconds.truncatingRemainder(dividingBy: 10)
+    } else {
+      newSeconds -= newSeconds.truncatingRemainder(dividingBy: 60)
+    }
+
+    self.seconds = newSeconds
+    self.updateTimerTime()
+  }
+
   override func mouseUp(with event: NSEvent) {
     let point = self.convert(event.locationInWindow, from: nil)
     if self.hitTest(point) == self, !self.didDrag {

--- a/Timer/MVClockView.swift
+++ b/Timer/MVClockView.swift
@@ -213,7 +213,8 @@ extension MVClockView {
   }
 
   func handleClick() {
-    if self.timerTask == nil, self.seconds > 0 {
+    guard self.seconds > 0 else { return }
+    if self.timerTask == nil {
       self.updateTimerTime()
       self.start()
     } else {
@@ -293,14 +294,12 @@ extension MVClockView {
     }
   }
 
-  private static let clockFaceHitPath = NSBezierPath(ovalIn: NSRect(x: 21, y: 21, width: 108, height: 108))
-
   override func hitTest(_ aPoint: NSPoint) -> NSView? {
     let view = super.hitTest(aPoint)
     if view == self.arrowView {
       return view
     }
-    if Self.clockFaceHitPath.contains(aPoint), self.seconds > 0 {
+    if view != nil {
       return self
     }
     return nil


### PR DESCRIPTION
## Summary

- Add scroll wheel and trackpad gesture support for setting the timer
- Trackpad uses fine-grained control, mouse wheel uses larger increments
- Snaps to same grid as arrow drag (10s under 5 min, 60s above)
- Change minutes and seconds label colors to Apple Lead (#191919) for better readability
- Expand hit test area to full window bounds so scroll works anywhere

Closes #115