### PR TITLE
fix: Xcode 16.4 Swift 6 build error

### DIFF
--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -1,4 +1,4 @@
-import AppKit
+@preconcurrency import AppKit
 import UserNotifications
 
 @main

--- a/Timer/MVClockView.swift
+++ b/Timer/MVClockView.swift
@@ -1,4 +1,4 @@
-import AppKit
+@preconcurrency import AppKit
 
 final class MVClockView: NSView {
   override var mouseDownCanMoveWindow: Bool { false }


### PR DESCRIPTION
Add `@preconcurrency import AppKit` to fix non-Sendable `Notification` errors when building with Xcode 16.4's stricter Swift 6 concurrency checking.

Fixes the CI build failure on the 2.1.0 release workflow.