### PR TITLE
fix: use macos-26 CI runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ name: Upload Release Asset
 jobs:
   build:
     name: Upload Release Asset
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   SwiftLint:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - name: Install SwiftLint

--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -1,4 +1,4 @@
-@preconcurrency import AppKit
+import AppKit
 import UserNotifications
 
 @main

--- a/Timer/MVClockView.swift
+++ b/Timer/MVClockView.swift
@@ -1,4 +1,4 @@
-@preconcurrency import AppKit
+import AppKit
 
 final class MVClockView: NSView {
   override var mouseDownCanMoveWindow: Bool { false }


### PR DESCRIPTION
Switch all workflows from `macos-latest` (Xcode 16.4) to `macos-26` (Xcode 26) and revert the unnecessary `@preconcurrency` workaround.

Fixes the release build failure.