### PR TITLE
Add keyboard shortcuts to adjust timer by minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ Enter digits to set minutes. A decimal point specifies seconds so `2.34` is 2 mi
 | <kbd>r</kbd> | Restart with last timer |
 | <kbd>+</kbd> or <kbd>↑</kbd> | Add a minute |
 | <kbd>-</kbd> or <kbd>↓</kbd> | Subtract a minute |
-| <kbd>option</kbd>+<kbd>+</kbd> or <kbd>option</kbd>+<kbd>↑</kbd> | Add 10 minutes |
-| <kbd>option</kbd>+<kbd>-</kbd> or <kbd>option</kbd>+<kbd>↓</kbd> | Subtract 10 minutes |
+| <kbd>shift</kbd>+<kbd>+</kbd> or <kbd>shift</kbd>+<kbd>↑</kbd> | Add 10 minutes |
+| <kbd>shift</kbd>+<kbd>-</kbd> or <kbd>shift</kbd>+<kbd>↓</kbd> | Subtract 10 minutes |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,13 @@ make
 
 Enter digits to set minutes. A decimal point specifies seconds so `2.34` is 2 minutes and 34 seconds.
 
-<kbd>backspace</kbd> or <kbd>escape</kbd> to edit.
-<kbd>enter</kbd> to start or pause the timer.
-<kbd>cmd</kbd>+<kbd>n</kbd> to create a new timer.
-<kbd>r</kbd> to restart with the last timer.
+| Key | Action |
+|-----|--------|
+| <kbd>backspace</kbd> or <kbd>escape</kbd> | Edit timer |
+| <kbd>enter</kbd> | Start or pause |
+| <kbd>cmd</kbd>+<kbd>n</kbd> | New timer |
+| <kbd>r</kbd> | Restart with last timer |
+| <kbd>+</kbd> or <kbd>↑</kbd> | Add a minute |
+| <kbd>-</kbd> or <kbd>↓</kbd> | Subtract a minute |
+| <kbd>option</kbd>+<kbd>+</kbd> or <kbd>option</kbd>+<kbd>↑</kbd> | Add 10 minutes |
+| <kbd>option</kbd>+<kbd>-</kbd> or <kbd>option</kbd>+<kbd>↓</kbd> | Subtract 10 minutes |

--- a/Timer/MVClockView+Behavior.swift
+++ b/Timer/MVClockView+Behavior.swift
@@ -60,33 +60,31 @@ extension MVClockView {
 
     if isAdd {
       self.adjustMinutes(by: minuteAmount)
-      return
     } else if isSubtract {
       self.adjustMinutes(by: -minuteAmount)
-      return
-    }
+    } else {
+      switch chars {
+      case ".":
+        self.inputSeconds.toggle()
 
-    switch chars {
-    case ".":
-      self.inputSeconds.toggle()
+      case "\u{1B}": // escape
+        self.resetTimer()
 
-    case "\u{1B}": // escape
-      self.resetTimer()
+      case "\u{7F}", "\u{F728}": // delete, forward delete
+        self.handleBackspace()
 
-    case "\u{7F}", "\u{F728}": // delete, forward delete
-      self.handleBackspace()
-
-    case "\r", " ", "\u{03}": // return, space, keypad enter
-      self.handleClick()
-
-    case "r":
-      if self.timerTask == nil, !self.paused, let seconds = self.lastTimerSeconds {
-        self.seconds = seconds
+      case "\r", " ", "\u{03}": // return, space, keypad enter
         self.handleClick()
-      }
 
-    default:
-      self.handleDigitInput(event)
+      case "r":
+        if self.timerTask == nil, !self.paused, let seconds = self.lastTimerSeconds {
+          self.seconds = seconds
+          self.handleClick()
+        }
+
+      default:
+        self.handleDigitInput(event)
+      }
     }
   }
 

--- a/Timer/MVClockView+Behavior.swift
+++ b/Timer/MVClockView+Behavior.swift
@@ -50,7 +50,23 @@ extension MVClockView {
   }
 
   override func keyUp(with event: NSEvent) {
-    switch event.charactersIgnoringModifiers {
+    let modifiers = event.modifierFlags
+    let chars = event.charactersIgnoringModifiers
+    let minuteAmount = modifiers.contains(.option) ? 10 : 1
+
+    // Use the physical key ("=" is the +/= key; shift state isn't reliable on keyUp)
+    let isAdd = chars == "\u{F700}" || chars == "=" // up arrow or +/= key
+    let isSubtract = chars == "\u{F701}" || chars == "-" // down arrow or -/_ key
+
+    if isAdd {
+      self.adjustMinutes(by: minuteAmount)
+      return
+    } else if isSubtract {
+      self.adjustMinutes(by: -minuteAmount)
+      return
+    }
+
+    switch chars {
     case ".":
       self.inputSeconds.toggle()
 
@@ -72,6 +88,11 @@ extension MVClockView {
     default:
       self.handleDigitInput(event)
     }
+  }
+
+  private func adjustMinutes(by minutes: Int) {
+    self.seconds = max(0, self.seconds + CGFloat(minutes * 60))
+    self.updateTimerTime()
   }
 
   private func resetTimer() {

--- a/Timer/MVClockView+Behavior.swift
+++ b/Timer/MVClockView+Behavior.swift
@@ -52,7 +52,7 @@ extension MVClockView {
   override func keyUp(with event: NSEvent) {
     let modifiers = event.modifierFlags
     let chars = event.charactersIgnoringModifiers
-    let minuteAmount = modifiers.contains(.option) ? 10 : 1
+    let minuteAmount = modifiers.contains(.shift) ? 10 : 1
 
     // Use the physical key ("=" is the +/= key; shift state isn't reliable on keyUp)
     let isAdd = chars == "\u{F700}" || chars == "=" // up arrow or +/= key

--- a/TimerUITests/TimerKeyboardInputTests.swift
+++ b/TimerUITests/TimerKeyboardInputTests.swift
@@ -156,16 +156,16 @@ final class TimerKeyboardInputTests: TimerUITestCase {
     XCTAssertTrue(window.exists, "Window should exist after pressing down arrow")
   }
 
-  func testOptionPlusAdds10Minutes() throws {
+  func testShiftPlusAdds10Minutes() throws {
     let window = app.windows.firstMatch
 
-    window.typeKey("=", modifierFlags: .option)
+    window.typeKey("=", modifierFlags: .shift)
     Thread.sleep(forTimeInterval: 0.2)
 
-    XCTAssertTrue(window.exists, "Window should exist after option+plus")
+    XCTAssertTrue(window.exists, "Window should exist after shift+plus")
   }
 
-  func testOptionMinusSubtracts10Minutes() throws {
+  func testShiftMinusSubtracts10Minutes() throws {
     let window = app.windows.firstMatch
 
     // Set 15 minutes first so there's room to subtract
@@ -173,10 +173,10 @@ final class TimerKeyboardInputTests: TimerUITestCase {
     window.typeKey("5", modifierFlags: [])
     Thread.sleep(forTimeInterval: 0.2)
 
-    window.typeKey("-", modifierFlags: .option)
+    window.typeKey("-", modifierFlags: .shift)
     Thread.sleep(forTimeInterval: 0.2)
 
-    XCTAssertTrue(window.exists, "Window should exist after option+minus")
+    XCTAssertTrue(window.exists, "Window should exist after shift+minus")
   }
 
   func testSubtractBelowZeroStaysAtZero() throws {

--- a/TimerUITests/TimerKeyboardInputTests.swift
+++ b/TimerUITests/TimerKeyboardInputTests.swift
@@ -112,6 +112,102 @@ final class TimerKeyboardInputTests: TimerUITestCase {
     Thread.sleep(forTimeInterval: 0.2)
   }
 
+  // MARK: - Minute Adjustment
+
+  func testPlusKeyAddsMinute() throws {
+    let window = app.windows.firstMatch
+
+    window.typeKey("=", modifierFlags: [])
+    Thread.sleep(forTimeInterval: 0.2)
+
+    XCTAssertTrue(window.exists, "Window should exist after pressing +")
+  }
+
+  func testMinusKeySubtractsMinute() throws {
+    let window = app.windows.firstMatch
+
+    window.typeKey("5", modifierFlags: [])
+    Thread.sleep(forTimeInterval: 0.2)
+
+    window.typeKey("-", modifierFlags: [])
+    Thread.sleep(forTimeInterval: 0.2)
+
+    XCTAssertTrue(window.exists, "Window should exist after pressing -")
+  }
+
+  func testUpArrowAddsMinute() throws {
+    let window = app.windows.firstMatch
+
+    window.typeKey(.upArrow, modifierFlags: [])
+    Thread.sleep(forTimeInterval: 0.2)
+
+    XCTAssertTrue(window.exists, "Window should exist after pressing up arrow")
+  }
+
+  func testDownArrowSubtractsMinute() throws {
+    let window = app.windows.firstMatch
+
+    window.typeKey("5", modifierFlags: [])
+    Thread.sleep(forTimeInterval: 0.2)
+
+    window.typeKey(.downArrow, modifierFlags: [])
+    Thread.sleep(forTimeInterval: 0.2)
+
+    XCTAssertTrue(window.exists, "Window should exist after pressing down arrow")
+  }
+
+  func testOptionPlusAdds10Minutes() throws {
+    let window = app.windows.firstMatch
+
+    window.typeKey("=", modifierFlags: .option)
+    Thread.sleep(forTimeInterval: 0.2)
+
+    XCTAssertTrue(window.exists, "Window should exist after option+plus")
+  }
+
+  func testOptionMinusSubtracts10Minutes() throws {
+    let window = app.windows.firstMatch
+
+    // Set 15 minutes first so there's room to subtract
+    window.typeKey("1", modifierFlags: [])
+    window.typeKey("5", modifierFlags: [])
+    Thread.sleep(forTimeInterval: 0.2)
+
+    window.typeKey("-", modifierFlags: .option)
+    Thread.sleep(forTimeInterval: 0.2)
+
+    XCTAssertTrue(window.exists, "Window should exist after option+minus")
+  }
+
+  func testSubtractBelowZeroStaysAtZero() throws {
+    let window = app.windows.firstMatch
+
+    // Timer starts at 0, subtracting should clamp to 0
+    window.typeKey("-", modifierFlags: [])
+    Thread.sleep(forTimeInterval: 0.2)
+
+    XCTAssertTrue(window.exists, "Window should exist after subtracting from zero")
+  }
+
+  func testAdjustMinutesWhileTimerRunning() throws {
+    let window = app.windows.firstMatch
+
+    window.typeKey("5", modifierFlags: [])
+    Thread.sleep(forTimeInterval: 0.2)
+    window.typeKey(.return, modifierFlags: [])
+    Thread.sleep(forTimeInterval: 0.3)
+
+    window.typeKey("=", modifierFlags: [])
+    Thread.sleep(forTimeInterval: 0.2)
+    window.typeKey("-", modifierFlags: [])
+    Thread.sleep(forTimeInterval: 0.2)
+
+    XCTAssertTrue(window.exists, "Window should exist after adjusting minutes while running")
+
+    window.typeKey(.escape, modifierFlags: [])
+    Thread.sleep(forTimeInterval: 0.2)
+  }
+
   func testDoublePeriodTogglesBackToMinutes() throws {
     let window = app.windows.firstMatch
 


### PR DESCRIPTION
## Summary                                                                                                        
                                                                                                                  
  Adds keyboard shortcuts to increment or decrement the timer while it is                                           
  running or paused, without needing to re-enter a time manually.                                                 
                                                                                                                    
  | Key | Action |                                                                                                
  |-----|--------|                                                                                                  
  | `+` or `↑` | Add 1 minute |                                                                                   
  | `-` or `↓` | Subtract 1 minute |                                                                                
  | `shift`+`+` or `shift`+`↑` | Add 10 minutes |                                                               
  | `shift`+`-` or `shift`+`↓` | Subtract 10 minutes |                                                            
                                                                                                                  
  Timer is clamped at 0 — subtracting below zero has no effect.                                                     
                                                                                                                  
  ## Changes                                                                                                        
                                                                                                                  
  - **`MVClockView+Behavior.swift`** — Added `adjustMinutes(by:)` helper and                                        
    wired up `+`/`-`/`↑`/`↓` keys (with optional `shift` modifier for ±10                                        
    minutes) in `keyUp(with:)`.                                                                                     
  - **`README.md`** — Reformatted keyboard shortcut list as a table and                                           
    documented the new shortcuts.                                                                                   
  - **`TimerKeyboardInputTests.swift`** — Added UI tests covering all new key                                     
    combinations, the zero-clamp behaviour, and adjustment while the timer is                                       
    running.   