### PR TITLE
Implement notification actions and categories for timer events

### DIFF
--- a/Timer.xcodeproj/project.pbxproj
+++ b/Timer.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		40A85EFA25A64C3100DA10CC /* alert-sound-2.caf in Resources */ = {isa = PBXBuildFile; fileRef = 40A85EF825A64C3100DA10CC /* alert-sound-2.caf */; };
 		41A37D0724426E360078EA40 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 41A37D0624426E360078EA40 /* Credits.rtf */; };
 		4C30BBFC1CA7C56500C45EBF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C30BBFB1CA7C56500C45EBF /* AppDelegate.swift */; };
+		4C30BBFF1CA7C56500C45EBF /* AppDelegate+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C30BC001CA7C56500C45EBF /* AppDelegate+Notifications.swift */; };
 		4C30BBFE1CA7C56500C45EBF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4C30BBFD1CA7C56500C45EBF /* Assets.xcassets */; };
 		4C30BC091CA7C81C00C45EBF /* MVWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C30BC081CA7C81C00C45EBF /* MVWindow.swift */; };
 		4C30BC0B1CA7C96700C45EBF /* MVMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C30BC0A1CA7C96700C45EBF /* MVMainView.swift */; };
@@ -61,6 +62,7 @@
 		41A37D0624426E360078EA40 /* Credits.rtf */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
 		4C30BBF81CA7C56500C45EBF /* Timer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Timer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C30BBFB1CA7C56500C45EBF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		4C30BC001CA7C56500C45EBF /* AppDelegate+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Notifications.swift"; sourceTree = "<group>"; };
 		4C30BBFD1CA7C56500C45EBF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4C30BC021CA7C56500C45EBF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4C30BC081CA7C81C00C45EBF /* MVWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MVWindow.swift; sourceTree = "<group>"; };
@@ -140,6 +142,7 @@
 			isa = PBXGroup;
 			children = (
 				4C30BBFB1CA7C56500C45EBF /* AppDelegate.swift */,
+				4C30BC001CA7C56500C45EBF /* AppDelegate+Notifications.swift */,
 				4C6F0F2B1CACF4B500E9A6F7 /* MVTimerController.swift */,
 				4C30BC081CA7C81C00C45EBF /* MVWindow.swift */,
 				4C30BC0A1CA7C96700C45EBF /* MVMainView.swift */,
@@ -329,6 +332,7 @@
 				4C6F0F2C1CACF4B500E9A6F7 /* MVTimerController.swift in Sources */,
 				4C30BC091CA7C81C00C45EBF /* MVWindow.swift in Sources */,
 				4C30BBFC1CA7C56500C45EBF /* AppDelegate.swift in Sources */,
+				4C30BBFF1CA7C56500C45EBF /* AppDelegate+Notifications.swift in Sources */,
 				4C30BC161CA7D94500C45EBF /* MVClockView.swift in Sources */,
 				4C30BC101CA7CFBB00C45EBF /* MVTitlebarAccessoryViewController.swift in Sources */,
 				AA000001AAAA000100000001 /* TimerLogic.swift in Sources */,

--- a/Timer/AppDelegate+Notifications.swift
+++ b/Timer/AppDelegate+Notifications.swift
@@ -1,0 +1,75 @@
+import AppKit
+import UserNotifications
+
+extension AppDelegate {
+  nonisolated func userNotificationCenter(
+    _: UNUserNotificationCenter,
+    willPresent _: UNNotification,
+    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+    completionHandler([.banner, .sound])
+  }
+
+  nonisolated func userNotificationCenter(
+    _: UNUserNotificationCenter,
+    didReceive response: UNNotificationResponse,
+    withCompletionHandler completionHandler: @escaping () -> Void) {
+    let actionIdentifier = response.actionIdentifier
+    let controllerIdentifier = response.notification.request.content.userInfo[
+      MVNotificationUserInfoKeys.controllerIdentifier
+    ] as? String
+
+    completionHandler()
+
+    DispatchQueue.main.async { [weak self] in
+      self?.handleNotificationAction(actionIdentifier, controllerIdentifier: controllerIdentifier)
+    }
+  }
+
+  func registerNotificationCategories() {
+    let restartAction = UNNotificationAction(
+      identifier: MVNotificationIdentifiers.restartTimerActionIdentifier,
+      title: "Restart",
+      options: []
+    )
+    let addFiveMinutesAction = UNNotificationAction(
+      identifier: MVNotificationIdentifiers.addFiveMinutesActionIdentifier,
+      title: "+5 min",
+      options: []
+    )
+    let stopAction = UNNotificationAction(
+      identifier: MVNotificationIdentifiers.stopTimerActionIdentifier,
+      title: "Stop",
+      options: [.destructive]
+    )
+    let category = UNNotificationCategory(
+      identifier: MVNotificationIdentifiers.timerCompleteCategoryIdentifier,
+      actions: [restartAction, addFiveMinutesAction, stopAction],
+      intentIdentifiers: [],
+      options: []
+    )
+
+    UNUserNotificationCenter.current().setNotificationCategories([category])
+  }
+
+  private func handleNotificationAction(_ actionIdentifier: String, controllerIdentifier: String?) {
+    let controller = self.controller(matching: controllerIdentifier)
+
+    switch actionIdentifier {
+    case MVNotificationIdentifiers.restartTimerActionIdentifier:
+      controller.restartLastTimer()
+
+    case MVNotificationIdentifiers.addFiveMinutesActionIdentifier:
+      controller.addTime(seconds: CGFloat(5 * 60))
+
+    case MVNotificationIdentifiers.stopTimerActionIdentifier:
+      controller.stopTimer()
+
+    case UNNotificationDefaultActionIdentifier:
+      controller.window?.makeKeyAndOrderFront(nil)
+      NSApplication.shared.activate(ignoringOtherApps: true)
+
+    default:
+      break
+    }
+  }
+}

--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -1,18 +1,6 @@
 import AppKit
 import UserNotifications
 
-private final class MVNotificationResponseCompletion: @unchecked Sendable {
-  private let completionHandler: () -> Void
-
-  init(_ completionHandler: @escaping () -> Void) {
-    self.completionHandler = completionHandler
-  }
-
-  func call() {
-    self.completionHandler()
-  }
-}
-
 @main
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
@@ -92,15 +80,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     switch input.lowercased() {
     case "stop":
-      clockView.paused = false
-      clockView.stop()
+      controller.stopTimer()
 
     case "reset":
-      clockView.paused = false
-      clockView.stop()
-      clockView.seconds = 0
-      clockView.updateTimerTime()
-      clockView.inputSeconds = false
+      controller.resetTimer()
 
     case "pause":
       if clockView.timerTask != nil {
@@ -182,11 +165,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     let controllerIdentifier = response.notification.request.content.userInfo[
       MVNotificationUserInfoKeys.controllerIdentifier
     ] as? String
-    let completion = MVNotificationResponseCompletion(completionHandler)
 
-    DispatchQueue.main.async { [weak self, completion] in
+    completionHandler()
+
+    DispatchQueue.main.async { [weak self] in
       self?.handleNotificationAction(actionIdentifier, controllerIdentifier: controllerIdentifier)
-      completion.call()
     }
   }
 
@@ -239,8 +222,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
       controller.addTime(seconds: CGFloat(5 * 60))
 
     case MVNotificationIdentifiers.stopTimerActionIdentifier:
-      controller.clockView.paused = false
-      controller.clockView.stop()
+      controller.stopTimer()
 
     case UNNotificationDefaultActionIdentifier:
       controller.window?.makeKeyAndOrderFront(nil)

--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -170,11 +170,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     let controllerIdentifier = response.notification.request.content.userInfo[
       MVNotificationUserInfoKeys.controllerIdentifier
     ] as? String
-    nonisolated(unsafe) let completionHandler = completionHandler
+
+    completionHandler()
 
     Task { @MainActor [weak self] in
       self?.handleNotificationAction(actionIdentifier, controllerIdentifier: controllerIdentifier)
-      completionHandler()
     }
   }
 
@@ -227,7 +227,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
       controller.addTime(seconds: CGFloat(5 * 60))
 
     case MVNotificationIdentifiers.stopTimerActionIdentifier:
-      controller.resetTimer()
+      controller.clockView.paused = false
+      controller.clockView.stop()
 
     case UNNotificationDefaultActionIdentifier:
       controller.window?.makeKeyAndOrderFront(nil)
@@ -249,6 +250,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     let controller = MVTimerController()
+    controller.window?.level = self.windowLevel
     self.controllers.append(controller)
     self.addBadgeToDock(controller: controller)
     return controller

--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -1,6 +1,18 @@
 import AppKit
 import UserNotifications
 
+private final class MVNotificationResponseCompletion: @unchecked Sendable {
+  private let completionHandler: () -> Void
+
+  init(_ completionHandler: @escaping () -> Void) {
+    self.completionHandler = completionHandler
+  }
+
+  func call() {
+    self.completionHandler()
+  }
+}
+
 @main
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
@@ -170,11 +182,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     let controllerIdentifier = response.notification.request.content.userInfo[
       MVNotificationUserInfoKeys.controllerIdentifier
     ] as? String
+    let completion = MVNotificationResponseCompletion(completionHandler)
 
-    completionHandler()
-
-    Task { @MainActor [weak self] in
+    DispatchQueue.main.async { [weak self, completion] in
       self?.handleNotificationAction(actionIdentifier, controllerIdentifier: controllerIdentifier)
+      completion.call()
     }
   }
 

--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -150,29 +150,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     return true
   }
 
-  nonisolated func userNotificationCenter(
-    _: UNUserNotificationCenter,
-    willPresent _: UNNotification,
-    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-    completionHandler([.banner, .sound])
-  }
-
-  nonisolated func userNotificationCenter(
-    _: UNUserNotificationCenter,
-    didReceive response: UNNotificationResponse,
-    withCompletionHandler completionHandler: @escaping () -> Void) {
-    let actionIdentifier = response.actionIdentifier
-    let controllerIdentifier = response.notification.request.content.userInfo[
-      MVNotificationUserInfoKeys.controllerIdentifier
-    ] as? String
-
-    completionHandler()
-
-    DispatchQueue.main.async { [weak self] in
-      self?.handleNotificationAction(actionIdentifier, controllerIdentifier: controllerIdentifier)
-    }
-  }
-
   func addBadgeToDock(controller: MVTimerController) {
     if self.currentlyInDock != controller {
       self.removeBadgeFromDock()
@@ -211,29 +188,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     self.staysOnTop = UserDefaults.standard.bool(forKey: MVUserDefaultsKeys.staysOnTop)
   }
 
-  private func handleNotificationAction(_ actionIdentifier: String, controllerIdentifier: String?) {
-    let controller = self.controller(matching: controllerIdentifier)
-
-    switch actionIdentifier {
-    case MVNotificationIdentifiers.restartTimerActionIdentifier:
-      controller.restartLastTimer()
-
-    case MVNotificationIdentifiers.addFiveMinutesActionIdentifier:
-      controller.addTime(seconds: CGFloat(5 * 60))
-
-    case MVNotificationIdentifiers.stopTimerActionIdentifier:
-      controller.stopTimer()
-
-    case UNNotificationDefaultActionIdentifier:
-      controller.window?.makeKeyAndOrderFront(nil)
-      NSApplication.shared.activate(ignoringOtherApps: true)
-
-    default:
-      break
-    }
-  }
-
-  private func controller(matching identifier: String?) -> MVTimerController {
+  func controller(matching identifier: String?) -> MVTimerController {
     if let identifier,
        let controller = self.controllers.first(where: { $0.identifier == identifier }) {
       return controller
@@ -248,32 +203,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     self.controllers.append(controller)
     self.addBadgeToDock(controller: controller)
     return controller
-  }
-
-  private func registerNotificationCategories() {
-    let restartAction = UNNotificationAction(
-      identifier: MVNotificationIdentifiers.restartTimerActionIdentifier,
-      title: "Restart",
-      options: []
-    )
-    let addFiveMinutesAction = UNNotificationAction(
-      identifier: MVNotificationIdentifiers.addFiveMinutesActionIdentifier,
-      title: "+5 min",
-      options: []
-    )
-    let stopAction = UNNotificationAction(
-      identifier: MVNotificationIdentifiers.stopTimerActionIdentifier,
-      title: "Stop",
-      options: [.destructive]
-    )
-    let category = UNNotificationCategory(
-      identifier: MVNotificationIdentifiers.timerCompleteCategoryIdentifier,
-      actions: [restartAction, addFiveMinutesAction, stopAction],
-      intentIdentifiers: [],
-      options: []
-    )
-
-    UNUserNotificationCenter.current().setNotificationCategories([category])
   }
 
   private func observeNotifications() {

--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -168,15 +168,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     withCompletionHandler completionHandler: @escaping () -> Void) {
     let actionIdentifier = response.actionIdentifier
     let controllerIdentifier = response.notification.request.content.userInfo[
-      MVNotificationIdentifiers.controllerIdentifierKey
+      MVNotificationUserInfoKeys.controllerIdentifier
     ] as? String
+    nonisolated(unsafe) let completionHandler = completionHandler
 
-    Task { @MainActor in
-      guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
-      appDelegate.handleNotificationAction(actionIdentifier, controllerIdentifier: controllerIdentifier)
+    Task { @MainActor [weak self] in
+      self?.handleNotificationAction(actionIdentifier, controllerIdentifier: controllerIdentifier)
+      completionHandler()
     }
-
-    completionHandler()
   }
 
   func addBadgeToDock(controller: MVTimerController) {
@@ -218,15 +217,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
   }
 
   private func handleNotificationAction(_ actionIdentifier: String, controllerIdentifier: String?) {
-    guard let controllerIdentifier,
-          let controller = self.controllers.first(where: { $0.identifier == controllerIdentifier }) else { return }
+    let controller = self.controller(matching: controllerIdentifier)
 
     switch actionIdentifier {
     case MVNotificationIdentifiers.restartTimerActionIdentifier:
       controller.restartLastTimer()
 
     case MVNotificationIdentifiers.addFiveMinutesActionIdentifier:
-      controller.addTime(seconds: 5 * 60)
+      controller.addTime(seconds: CGFloat(5 * 60))
 
     case MVNotificationIdentifiers.stopTimerActionIdentifier:
       controller.resetTimer()
@@ -238,6 +236,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     default:
       break
     }
+  }
+
+  private func controller(matching identifier: String?) -> MVTimerController {
+    if let identifier,
+       let controller = self.controllers.first(where: { $0.identifier == identifier }) {
+      return controller
+    }
+
+    if let controller = self.controllers.first {
+      return controller
+    }
+
+    let controller = MVTimerController()
+    self.controllers.append(controller)
+    self.addBadgeToDock(controller: controller)
+    return controller
   }
 
   private func registerNotificationCategories() {

--- a/Timer/AppDelegate.swift
+++ b/Timer/AppDelegate.swift
@@ -27,6 +27,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     self.addBadgeToDock(controller: controller)
 
     UNUserNotificationCenter.current().delegate = self
+    self.registerNotificationCategories()
     Task {
       do {
         try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound])
@@ -161,6 +162,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     completionHandler([.banner, .sound])
   }
 
+  nonisolated func userNotificationCenter(
+    _: UNUserNotificationCenter,
+    didReceive response: UNNotificationResponse,
+    withCompletionHandler completionHandler: @escaping () -> Void) {
+    let actionIdentifier = response.actionIdentifier
+    let controllerIdentifier = response.notification.request.content.userInfo[
+      MVNotificationIdentifiers.controllerIdentifierKey
+    ] as? String
+
+    Task { @MainActor in
+      guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
+      appDelegate.handleNotificationAction(actionIdentifier, controllerIdentifier: controllerIdentifier)
+    }
+
+    completionHandler()
+  }
+
   func addBadgeToDock(controller: MVTimerController) {
     if self.currentlyInDock != controller {
       self.removeBadgeFromDock()
@@ -197,6 +215,55 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
   private func handleUserDefaultsChange() {
     self.staysOnTop = UserDefaults.standard.bool(forKey: MVUserDefaultsKeys.staysOnTop)
+  }
+
+  private func handleNotificationAction(_ actionIdentifier: String, controllerIdentifier: String?) {
+    guard let controllerIdentifier,
+          let controller = self.controllers.first(where: { $0.identifier == controllerIdentifier }) else { return }
+
+    switch actionIdentifier {
+    case MVNotificationIdentifiers.restartTimerActionIdentifier:
+      controller.restartLastTimer()
+
+    case MVNotificationIdentifiers.addFiveMinutesActionIdentifier:
+      controller.addTime(seconds: 5 * 60)
+
+    case MVNotificationIdentifiers.stopTimerActionIdentifier:
+      controller.resetTimer()
+
+    case UNNotificationDefaultActionIdentifier:
+      controller.window?.makeKeyAndOrderFront(nil)
+      NSApplication.shared.activate(ignoringOtherApps: true)
+
+    default:
+      break
+    }
+  }
+
+  private func registerNotificationCategories() {
+    let restartAction = UNNotificationAction(
+      identifier: MVNotificationIdentifiers.restartTimerActionIdentifier,
+      title: "Restart",
+      options: []
+    )
+    let addFiveMinutesAction = UNNotificationAction(
+      identifier: MVNotificationIdentifiers.addFiveMinutesActionIdentifier,
+      title: "+5 min",
+      options: []
+    )
+    let stopAction = UNNotificationAction(
+      identifier: MVNotificationIdentifiers.stopTimerActionIdentifier,
+      title: "Stop",
+      options: [.destructive]
+    )
+    let category = UNNotificationCategory(
+      identifier: MVNotificationIdentifiers.timerCompleteCategoryIdentifier,
+      actions: [restartAction, addFiveMinutesAction, stopAction],
+      intentIdentifiers: [],
+      options: []
+    )
+
+    UNUserNotificationCenter.current().setNotificationCategories([category])
   }
 
   private func observeNotifications() {

--- a/Timer/MVTimerController.swift
+++ b/Timer/MVTimerController.swift
@@ -3,6 +3,8 @@ import AVFoundation
 import UserNotifications
 
 final class MVTimerController: NSWindowController {
+  let identifier = UUID().uuidString
+
   private weak var dockMenuItem: NSMenuItem?
   let clockView = MVClockView()
 
@@ -73,6 +75,8 @@ final class MVTimerController: NSWindowController {
   private func handleClockTimer() {
     let content = UNMutableNotificationContent()
     content.title = "It's time! 🕘"
+    content.categoryIdentifier = MVNotificationIdentifiers.timerCompleteCategoryIdentifier
+    content.userInfo = [MVNotificationIdentifiers.controllerIdentifierKey: self.identifier]
 
     let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
     UNUserNotificationCenter.current().add(request)
@@ -99,5 +103,23 @@ final class MVTimerController: NSWindowController {
     } else {
       self.soundURL = nil
     }
+  }
+
+  func restartLastTimer() {
+    guard let seconds = self.clockView.lastTimerSeconds, seconds > 0 else { return }
+    self.clockView.startTimer(seconds: seconds)
+  }
+
+  func addTime(seconds: CGFloat) {
+    let currentSeconds = self.clockView.timerTask != nil || self.clockView.paused ? self.clockView.seconds : 0
+    self.clockView.startTimer(seconds: currentSeconds + seconds)
+  }
+
+  func resetTimer() {
+    self.clockView.paused = false
+    self.clockView.stop()
+    self.clockView.seconds = 0
+    self.clockView.updateTimerTime()
+    self.clockView.inputSeconds = false
   }
 }

--- a/Timer/MVTimerController.swift
+++ b/Timer/MVTimerController.swift
@@ -76,7 +76,7 @@ final class MVTimerController: NSWindowController {
     let content = UNMutableNotificationContent()
     content.title = "It's time! 🕘"
     content.categoryIdentifier = MVNotificationIdentifiers.timerCompleteCategoryIdentifier
-    content.userInfo = [MVNotificationIdentifiers.controllerIdentifierKey: self.identifier]
+    content.userInfo = [MVNotificationUserInfoKeys.controllerIdentifier: self.identifier]
 
     let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
     UNUserNotificationCenter.current().add(request)

--- a/Timer/MVTimerController.swift
+++ b/Timer/MVTimerController.swift
@@ -9,6 +9,7 @@ final class MVTimerController: NSWindowController {
   let clockView = MVClockView()
 
   private var audioPlayer: AVAudioPlayer? // player must be kept in memory
+  private var userAttentionRequest: Int?
   private var soundURL = Bundle.main.url(forResource: "alert-sound", withExtension: "caf")
 
   convenience init() {
@@ -73,15 +74,21 @@ final class MVTimerController: NSWindowController {
   }
 
   private func handleClockTimer() {
+    self.stopCompletionEffects()
+
     let content = UNMutableNotificationContent()
     content.title = "It's time! 🕘"
     content.categoryIdentifier = MVNotificationIdentifiers.timerCompleteCategoryIdentifier
     content.userInfo = [MVNotificationUserInfoKeys.controllerIdentifier: self.identifier]
 
     let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
-    UNUserNotificationCenter.current().add(request)
+    UNUserNotificationCenter.current().add(request) { error in
+      if let error {
+        NSLog("Notification scheduling failed: %@", error.localizedDescription)
+      }
+    }
 
-    NSApplication.shared.requestUserAttention(.criticalRequest)
+    self.userAttentionRequest = NSApplication.shared.requestUserAttention(.criticalRequest)
 
     self.playAlarmSound()
   }
@@ -107,19 +114,36 @@ final class MVTimerController: NSWindowController {
 
   func restartLastTimer() {
     guard let seconds = self.clockView.lastTimerSeconds, seconds > 0 else { return }
+    self.stopCompletionEffects()
     self.clockView.startTimer(seconds: seconds)
   }
 
   func addTime(seconds: CGFloat) {
     let currentSeconds = self.clockView.timerTask != nil || self.clockView.paused ? self.clockView.seconds : 0
+    self.stopCompletionEffects()
     self.clockView.startTimer(seconds: currentSeconds + seconds)
   }
 
-  func resetTimer() {
+  func stopTimer() {
+    self.stopCompletionEffects()
     self.clockView.paused = false
     self.clockView.stop()
+  }
+
+  func resetTimer() {
+    self.stopTimer()
     self.clockView.seconds = 0
     self.clockView.updateTimerTime()
     self.clockView.inputSeconds = false
+  }
+
+  private func stopCompletionEffects() {
+    self.audioPlayer?.stop()
+    self.audioPlayer = nil
+
+    if let userAttentionRequest {
+      NSApplication.shared.cancelUserAttentionRequest(userAttentionRequest)
+      self.userAttentionRequest = nil
+    }
   }
 }

--- a/Timer/MVUserDefaultsKeys.swift
+++ b/Timer/MVUserDefaultsKeys.swift
@@ -5,8 +5,11 @@ enum MVUserDefaultsKeys {
 
 enum MVNotificationIdentifiers {
   static let timerCompleteCategoryIdentifier = "timerComplete"
-  static let controllerIdentifierKey = "controllerIdentifier"
   static let restartTimerActionIdentifier = "restartTimer"
   static let addFiveMinutesActionIdentifier = "addFiveMinutes"
   static let stopTimerActionIdentifier = "stopTimer"
+}
+
+enum MVNotificationUserInfoKeys {
+  static let controllerIdentifier = "controllerIdentifier"
 }

--- a/Timer/MVUserDefaultsKeys.swift
+++ b/Timer/MVUserDefaultsKeys.swift
@@ -2,3 +2,11 @@ enum MVUserDefaultsKeys {
   static let staysOnTop = "staysOnTop"
   static let soundIndex = "soundIndex"
 }
+
+enum MVNotificationIdentifiers {
+  static let timerCompleteCategoryIdentifier = "timerComplete"
+  static let controllerIdentifierKey = "controllerIdentifier"
+  static let restartTimerActionIdentifier = "restartTimer"
+  static let addFiveMinutesActionIdentifier = "addFiveMinutes"
+  static let stopTimerActionIdentifier = "stopTimer"
+}


### PR DESCRIPTION
This pull request adds actionable notifications to the timer application, allowing users to interact directly with timer notifications (e.g., restart, add time, stop) and improves how notifications are handled and routed to the correct timer window. The main changes include registering notification categories, handling notification actions, associating notifications with specific timer controllers, and adding new timer control methods.

**Notification actions and handling:**

* Registered a notification category with three actions ("Restart", "+5 min", "Stop") for timer completion notifications, enabling actionable notifications in the app (`registerNotificationCategories` in `AppDelegate.swift`). [[1]](diffhunk://#diff-6cc8d3fb96e594e3b4349fb0fda9d92774f1c9202b44d651a21a14a2ca770abfR30) [[2]](diffhunk://#diff-6cc8d3fb96e594e3b4349fb0fda9d92774f1c9202b44d651a21a14a2ca770abfR220-R268)
* Implemented a handler for notification actions that routes the selected action to the appropriate timer controller based on a unique identifier in the notification payload (`userNotificationCenter(_:didReceive:withCompletionHandler:)` and `handleNotificationAction` in `AppDelegate.swift`). [[1]](diffhunk://#diff-6cc8d3fb96e594e3b4349fb0fda9d92774f1c9202b44d651a21a14a2ca770abfR165-R181) [[2]](diffhunk://#diff-6cc8d3fb96e594e3b4349fb0fda9d92774f1c9202b44d651a21a14a2ca770abfR220-R268)

**Timer controller enhancements:**

* Added a unique `identifier` property to each `MVTimerController` instance to associate notifications with specific timer windows.
* Modified timer completion notifications to include the controller identifier and category, enabling precise action routing.

**Timer control methods:**

* Added new methods to `MVTimerController` for restarting the last timer, adding five minutes, and resetting the timer, supporting the new notification actions.

**Identifiers centralization:**

* Introduced a new `MVNotificationIdentifiers` enum to centralize all notification-related string constants.